### PR TITLE
feat(时间): 支持 HH:MM:SS 格式的解析与格式化

### DIFF
--- a/src/utils/bizUtil.ts
+++ b/src/utils/bizUtil.ts
@@ -195,12 +195,56 @@ export const getSummarize = (title: string | undefined, segments: Segment[] | un
 }
 
 /**
- * @param time '03:10'
+ * 将 MM:SS 或 HH:MM:SS 格式的时间字符串转换为总秒数。
+ * @param time '03:10' 或 '01:03:10' 格式的时间字符串
+ * @returns number 总秒数，如果格式无效则返回 0 或 NaN (根据下面选择)。
+ *                 建议添加更严格的错误处理，例如抛出错误。
  */
 export const parseStrTimeToSeconds = (time: string): number => {
-  const parts = time.split(':')
-  return parseInt(parts[0]) * 60 + parseInt(parts[1])
-}
+  // 1. 基本输入验证 (可选但推荐)
+  if (!time || typeof time !== 'string') {
+    console.warn(`Invalid input type for time: ${typeof time}`);
+    return 0; // 或者 return NaN;
+  }
+
+  const parts = time.split(':');
+  const partCount = parts.length;
+
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+
+  try {
+    if (partCount === 2) {
+      // 格式: MM:SS
+      minutes = parseInt(parts[0]);
+      seconds = parseInt(parts[1]);
+    } else if (partCount === 3) {
+      // 格式: HH:MM:SS
+      hours = parseInt(parts[0]);
+      minutes = parseInt(parts[1]);
+      seconds = parseInt(parts[2]);
+    } else {
+      // 格式无效
+      console.warn(`Invalid time format: "${time}". Expected MM:SS or HH:MM:SS.`);
+      return 0; // 或者 return NaN;
+    }
+
+    // 2. 验证解析出的部分是否为有效数字
+    if (isNaN(hours) || isNaN(minutes) || isNaN(seconds)) {
+        console.warn(`Invalid numeric values in time string: "${time}"`);
+        return 0; // 或者 return NaN;
+    }
+
+    // 3. 计算总秒数
+    return hours * 3600 + minutes * 60 + seconds;
+
+  } catch (error) {
+    // 捕获潜在的错误 (虽然在此逻辑中不太可能，但以防万一)
+    console.error(`Error parsing time string: "${time}"`, error);
+    return 0; // 或者 return NaN;
+  }
+};
 
 /**
  * @param time '00:04:11,599' or '00:04:11.599' or '04:11,599' or '04:11.599'

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -5,13 +5,40 @@ export const isEdgeBrowser = () => {
   return userAgent.includes('edg/') && !userAgent.includes('edge/')
 }
 
-export const formatTime = (time: number) => {
-  if (!time) return '00:00'
+/**
+ * 将总秒数格式化为 MM:SS 或 HH:MM:SS 格式的字符串。
+ * 如果时间小于 1 小时，则使用 MM:SS 格式。
+ * 如果时间大于或等于 1 小时，则使用 HH:MM:SS 格式。
+ *
+ * @param time 总秒数 (number)
+ * @returns string 格式化后的时间字符串 ('MM:SS' 或 'HH:MM:SS')
+ */
+export const formatTime = (time: number): string => {
+  // 1. 输入验证和处理 0 或负数的情况
+  if (typeof time !== 'number' || isNaN(time) || time <= 0) {
+    return '00:00'; // 对于无效输入、0 或负数，返回 '00:00'
+  }
 
-  const minutes = Math.floor(time / 60)
-  const seconds = Math.floor(time % 60)
-  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
-}
+  // 取整确保我们处理的是整数秒
+  const totalSeconds = Math.floor(time);
+
+  // 2. 计算小时、分钟和秒
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  // 3. 格式化各个部分，确保是两位数 (例如 0 -> '00', 5 -> '05', 10 -> '10')
+  const formattedSeconds = seconds.toString().padStart(2, '0');
+  const formattedMinutes = minutes.toString().padStart(2, '0');
+
+  // 4. 根据是否有小时来决定最终格式
+  if (hours > 0) {
+    const formattedHours = hours.toString().padStart(2, '0');
+    return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`;
+  } else {
+    return `${formattedMinutes}:${formattedSeconds}`;
+  }
+};
 
 /**
  * @param time 2.82


### PR DESCRIPTION
改进 `parseStrTimeToSeconds` 以处理 `MM:SS` 和 `HH:MM:SS` 输入。更新 `formatTime` 以在存在小时的情况下输出 `HH:MM:SS` 格式。

问题：目前这个插件对于超过一小时的视频，还在用 `MM:SS` 格式表示时间，而不是 `HH:MM:SS` 格式，比如 `01:15:55` 就会写成 `75:55`

修改：无论是发给 LLM 的消息中，还是在插件上显示的时间字符串，都让它支持 `HH:MM:SS` 格式，这样对超过一小时的长视频总结，显示的时间格式更美观，与播放器的时间格式保持了一致。改后样式如下

![image](https://github.com/user-attachments/assets/8694ad1d-aecb-46ba-828e-7d2ec0a73db3)
